### PR TITLE
Google Analytics

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,5 +9,8 @@ baseurl: "/website20" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 theme: jekyll-agency
 
+analytics:
+  google: UA-66983412-1
+
 collections:
   portfolio:


### PR DESCRIPTION
It seems like this theme already comes with Google Analytics support so I didn't have to follow the other steps [Set up Google Analytics](https://desiredpersona.com/google-analytics-jekyll/). After adding the tracking code in _config.yml file..I checked the _site folder and Google Analytics tracking code was automatically added to the "head" section of the index.html file. 
I am not sure if this is working correctly? let me know if there is anything missing. 