### PR TITLE
Added Disqus comments to blog posts

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,7 +20,7 @@ pagination:
   enabled: true
   debug: false
   sort_reverse: true
-  collection: 'posts'
+  collection: "posts"
   per_page: 8
-  permalink: '/page/:num/'
+  permalink: "/page/:num/"
 exclude: [vendor]

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,3 +11,13 @@ title: Post
     </p>
   </div>
 </div>
+<div id="disqus_thread"></div>
+<script>
+    (function() { // DON'T EDIT BELOW THIS LINE
+    var d = document, s = d.createElement('script');
+    s.src = 'https://codefornepal-1.disqus.com/embed.js';
+    s.setAttribute('data-timestamp', +new Date());
+    (d.head || d.body).appendChild(s);
+    })();
+</script>
+<noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>


### PR DESCRIPTION
Added comments to blog posts using Disqus: [example](https://i.imgur.com/YhLk7CI.png)

In the future it would probably be better to migrate to [Staticman](https://staticman.net/) which entails a more complicated configuration process