### PR TITLE
Fixed footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -35,7 +35,7 @@
             </li>
           </ul>
         </div>
-        <div class="col-md-5">
+        <div class="col-md-11">
           <span class="code">{{ site.data.sitetext.footer.license }}</span>
         </div>
       </div>

--- a/_sass/layout/_footer.scss
+++ b/_sass/layout/_footer.scss
@@ -13,7 +13,6 @@
   span.code{
     font-size: 90%;
     line-height: 40px;
-    white-space: nowrap;
     color: white;
     @include heading-font;
   }
@@ -28,29 +27,6 @@
     }
   }
 }
-
-@media only screen and (max-width: 765px) {
-  .footer {
-    height: 390px;
-    span.code{
-      white-space: pre-wrap;
-    }
-  }
-}
-
-@media only screen and (min-width: 765px) and (max-width: 1250px) {
-.col-md-5 {
-    flex: auto!important;
-    max-width: 100%!important;
-}
-.footer {
-  height: 250px;
-  span.code{
-    white-space: pre-wrap;
-  }
-}
-}
-
 ul.social-buttons {
   margin-bottom: 0;
   li {


### PR DESCRIPTION
Some of the footer texts were getting cut when changed to different screen sizes(small) 
![footererror](https://user-images.githubusercontent.com/88110121/128897244-0e51b498-573a-4629-95be-0ec2ff60c22c.png)

This PR fixes this issue.
